### PR TITLE
fix: datepicker to use today as default and change method.

### DIFF
--- a/src/components/EntryForm.jsx
+++ b/src/components/EntryForm.jsx
@@ -13,6 +13,9 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import React, { useEffect, useState } from 'react'
 import vgrades from '../data/VGrades'
 import yosemiteGrades from '../data/YosemiteGrades'
+import dayjs from 'dayjs' 
+
+const today = dayjs()
 
 export default function EntryForm(props) {
   const modalStyle = {
@@ -33,7 +36,7 @@ export default function EntryForm(props) {
 
   const [grade, setGrade] = useState('')
   const [location, setLocation] = useState('')
-  const [date, setDate] = useState(null) // TODO - Make this value today's date. dayjs() is returning an error
+  const [date, setDate] = useState() // TODO - Make this value today's date. dayjs() is returning an error
   const [mpLink, setMpLink] = useState('')
   const [climbingType, setClimbingType] = useState('')
 
@@ -48,8 +51,7 @@ export default function EntryForm(props) {
   }, [date])
 
   const handleDateChange = (newDate) => {
-    const newSelectedDate = newDate.format('MM/DD/YYYY').toString()
-    setDate(newSelectedDate)
+	setDate(newDate)
   }
 
   const onSubmit = () => {
@@ -83,12 +85,12 @@ export default function EntryForm(props) {
         >
           <LocalizationProvider dateAdapter={AdapterDayjs}>
             <DatePicker
-              // defaultValue={dayjs()}
+              defaultValue={today}
               label="Date of climb"
               value={date}
               onChange={handleDateChange}
-              // inputRef={dateRef}
               sx={{ width: 2 / 5 }}
+			  format="MM/DD/YYYY"
             />
           </LocalizationProvider>
           <FormControl>

--- a/src/components/EntryForm.jsx
+++ b/src/components/EntryForm.jsx
@@ -15,8 +15,6 @@ import vgrades from '../data/VGrades'
 import yosemiteGrades from '../data/YosemiteGrades'
 import dayjs from 'dayjs' 
 
-const today = dayjs()
-
 export default function EntryForm(props) {
   const modalStyle = {
     bgcolor: 'white',
@@ -36,7 +34,7 @@ export default function EntryForm(props) {
 
   const [grade, setGrade] = useState('')
   const [location, setLocation] = useState('')
-  const [date, setDate] = useState() // TODO - Make this value today's date. dayjs() is returning an error
+  const [date, setDate] = useState()
   const [mpLink, setMpLink] = useState('')
   const [climbingType, setClimbingType] = useState('')
 
@@ -58,7 +56,8 @@ export default function EntryForm(props) {
     let id = getUniqueID()
     const model = {
       id,
-      date,
+	  // ensure we format the date here on submit, so our data layer is correctly formatted before hand.
+	  date: date.format('MM/DD/YYYY').toString(),
       climbingType,
       grade,
       location,
@@ -85,7 +84,7 @@ export default function EntryForm(props) {
         >
           <LocalizationProvider dateAdapter={AdapterDayjs}>
             <DatePicker
-              defaultValue={today}
+              defaultValue={dayjs()}
               label="Date of climb"
               value={date}
               onChange={handleDateChange}


### PR DESCRIPTION
# DEMO
https://github.com/RM-Evans/climbing-journal/assets/39814328/9cf577f7-65e9-40c6-907f-b90982b7fa1c

# TLDR
datepicker to use today as default value and fixed the change method to save the dayjs object, instead of the string, then on submit we format it to string then.

# Additional information
none.